### PR TITLE
Added new --delete-file-on-reboot command

### DIFF
--- a/NefConUtil.sln.DotSettings
+++ b/NefConUtil.sln.DotSettings
@@ -1,7 +1,11 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=attribs/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Bugprone/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=cppcoreguidelines/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=efcon/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=efconc/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ELPP/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Hicpp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=luid/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=nefcon/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=winapi/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/NefConUtil.sln.DotSettings
+++ b/NefConUtil.sln.DotSettings
@@ -2,4 +2,6 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=attribs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=efcon/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ELPP/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=nefcon/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=luid/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=nefcon/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=winapi/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/NefConSetup.h
+++ b/src/NefConSetup.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "easylogging++.h"
 #include "framework.h"
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
@@ -22,7 +23,7 @@ namespace winapi
 
     BOOL GetLogonSID(HANDLE hToken, PSID *ppsid);
 
-    BOOL TakeFileOwnership(LPCWSTR file);
+    BOOL TakeFileOwnership(el::Logger* logger, LPCWSTR file);
 
     BOOL SetPrivilege(LPCWSTR privilege, int enable);
 };

--- a/src/NefConSetup.h
+++ b/src/NefConSetup.h
@@ -19,4 +19,10 @@ namespace winapi
     std::string GetImageBasePath();
 
     DWORD IsAppRunningAsAdminMode(PBOOL IsAdmin);
+
+    BOOL GetLogonSID(HANDLE hToken, PSID *ppsid);
+
+    BOOL TakeFileOwnership(LPCWSTR file);
+
+    BOOL SetPrivilege(LPCWSTR privilege, int enable);
 };

--- a/src/NefConUtil.cpp
+++ b/src/NefConUtil.cpp
@@ -1,4 +1,6 @@
 // ReSharper disable CppTooWideScope
+// ReSharper disable CppClangTidyBugproneNarrowingConversions
+// ReSharper disable CppClangTidyHicppAvoidGoto
 #include "NefConUtil.h"
 
 using namespace colorwin;
@@ -693,7 +695,7 @@ int main(int argc, char* argv[])
 			}
 
 			// ...and try again
-			goto retryRemove;
+			goto retryRemove;  // NOLINT(cppcoreguidelines-avoid-goto)
 		}
 
 		if (!ret)

--- a/src/NefConUtil.cpp
+++ b/src/NefConUtil.cpp
@@ -680,7 +680,7 @@ int main(int argc, char* argv[])
 
 		if (!ret && GetLastError() == ERROR_ACCESS_DENIED)
 		{
-			if (!winapi::TakeFileOwnership(ConvertAnsiToWide(filePath).c_str()))
+			if (!winapi::TakeFileOwnership(logger, ConvertAnsiToWide(filePath).c_str()))
 			{
 				logger->error("Failed to take ownership of file, error: %v",
 					winapi::GetLastErrorStdStr());

--- a/src/NefConUtil.cpp
+++ b/src/NefConUtil.cpp
@@ -678,8 +678,10 @@ int main(int argc, char* argv[])
 	retryRemove:
 		const BOOL ret = MoveFileExA(filePath.c_str(), NULL, MOVEFILE_DELAY_UNTIL_REBOOT);
 
+		// if this happens despite elevated permissions...
 		if (!ret && GetLastError() == ERROR_ACCESS_DENIED)
 		{
+			// ...take ownership of protected file (e.g. within the system directories)...
 			if (!winapi::TakeFileOwnership(logger, ConvertAnsiToWide(filePath).c_str()))
 			{
 				logger->error("Failed to take ownership of file, error: %v",
@@ -690,6 +692,7 @@ int main(int argc, char* argv[])
 				return GetLastError();
 			}
 
+			// ...and try again
 			goto retryRemove;
 		}
 

--- a/src/NefConUtil.rc
+++ b/src/NefConUtil.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,7,2,0
- PRODUCTVERSION 1,7,2,0
+ FILEVERSION 1,8,0,0
+ PRODUCTVERSION 1,8,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -69,12 +69,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Nefarius Software Solutions e.U."
             VALUE "FileDescription", "Nefarius' Device Console Utility"
-            VALUE "FileVersion", "1.7.2.0"
+            VALUE "FileVersion", "1.8.0.0"
             VALUE "InternalName", "nefcon.exe"
             VALUE "LegalCopyright", "Copyright (C) 2022 Nefarius Software Solutions e.U."
             VALUE "OriginalFilename", "nefcon.exe"
             VALUE "ProductName", "nefcon"
-            VALUE "ProductVersion", "1.7.2.0"
+            VALUE "ProductVersion", "1.8.0.0"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
## Changes

- Added new `--delete-file-on-reboot` CLI flag (with `--file-path` option) which schedules deletion of the given file on system reboot. The command also automatically takes ownership of the file if necessary (e.g. if locked by TRUSTED_INSTALLER in a system directory or similar).
- Misc. silencing of warnings and code clean-up
- Bumped version to 1.8.0.0