### PR TITLE
Change Winget Releaser runner to `ubuntu-latest`

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish:
-    runs-on: windows-latest # Action can only run on Windows
+    runs-on: ubuntu-latest
     steps:
       - uses: vedantmgoyal2009/winget-releaser@v2
         with:


### PR DESCRIPTION
The Winget Releaser action now works on all runners, and I think the Ubuntu runner is slightly faster.