### PR TITLE
Pin Komac to the multi-architecture ZIP fix so WinGet submissions kee…

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -6,9 +6,57 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@main
-        with:
-          identifier: Nefarius.nefcon
-          installers-regex: '\.zip$'
-          token: ${{ secrets.WINGET_TOKEN }}
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      # Pin Komac to the merge that restored architecture detection for
+      # multi-architecture ZIP installers (russellbanks/Komac#1609).
+      # Latest released Komac 2.16.0 marks every nested installer as
+      # `neutral`, which WinGet rejects.
+      - name: Install Komac
+        run: >-
+          cargo install --git https://github.com/russellbanks/Komac.git
+          --rev 22ff95bb888399829dbe43af72a41a59436a739c
+          --locked --force
+
+      - name: Resolve version and installer URLs
+        id: release
+        env:
+          ASSETS: ${{ toJson(github.event.release.assets) }}
+        run: |
+          version="${{ github.event.release.tag_name }}"
+          version="${version#v}"
+          urls=$(echo "$ASSETS" | jq -r '[.[] | select(.name | test("\\.zip$")) | .browser_download_url] | join(" ")')
+          if [ -z "$urls" ]; then
+            echo "::error::No .zip release asset found"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "urls=$urls" >> "$GITHUB_OUTPUT"
+
+      - name: Sync winget-pkgs fork
+        env:
+          KOMAC_FORK_OWNER: ${{ github.repository_owner }}
+          GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: komac sync-fork
+
+      - name: Submit WinGet manifest
+        env:
+          KOMAC_FORK_OWNER: ${{ github.repository_owner }}
+          KOMAC_CREATED_WITH: nefcon GitHub Actions
+          KOMAC_CREATED_WITH_URL: ${{ github.server_url }}/${{ github.repository }}/blob/HEAD/.github/workflows/winget.yml
+          GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: >-
+          komac update Nefarius.nefcon
+          --version ${{ steps.release.outputs.version }}
+          --submit
+          --urls ${{ steps.release.outputs.urls }}
+
+      - name: Clean up merged submission branches
+        env:
+          KOMAC_FORK_OWNER: ${{ github.repository_owner }}
+          GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: komac cleanup --only-merged

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -6,11 +6,14 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions: {}
     env:
       CARGO_TERM_COLOR: always
     steps:
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master, 2026-08-05
+        with:
+          toolchain: stable
 
       # Pin Komac to the merge that restored architecture detection for
       # multi-architecture ZIP installers (russellbanks/Komac#1609).
@@ -26,9 +29,9 @@ jobs:
         id: release
         env:
           ASSETS: ${{ toJson(github.event.release.assets) }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          version="${{ github.event.release.tag_name }}"
-          version="${version#v}"
+          version="${TAG_NAME#v}"
           urls=$(echo "$ASSETS" | jq -r '[.[] | select(.name | test("\\.zip$")) | .browser_download_url] | join(" ")')
           if [ -z "$urls" ]; then
             echo "::error::No .zip release asset found"
@@ -49,11 +52,14 @@ jobs:
           KOMAC_CREATED_WITH: nefcon GitHub Actions
           KOMAC_CREATED_WITH_URL: ${{ github.server_url }}/${{ github.repository }}/blob/HEAD/.github/workflows/winget.yml
           GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
-        run: >-
-          komac update Nefarius.nefcon
-          --version ${{ steps.release.outputs.version }}
-          --submit
-          --urls ${{ steps.release.outputs.urls }}
+          PACKAGE_VERSION: ${{ steps.release.outputs.version }}
+          INSTALLER_URLS: ${{ steps.release.outputs.urls }}
+        run: |
+          read -r -a urls <<< "$INSTALLER_URLS"
+          komac update Nefarius.nefcon \
+            --version "$PACKAGE_VERSION" \
+            --submit \
+            --urls "${urls[@]}"
 
       - name: Clean up merged submission branches
         env:

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master, 2026-08-05
         with:
-          toolchain: stable
+          toolchain: 1.89.0
 
       # Pin Komac to the merge that restored architecture detection for
       # multi-architecture ZIP installers (russellbanks/Komac#1609).


### PR DESCRIPTION
…p arm64/x64/x86.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved the reliability and security of Windows package publishing.
  - Release metadata and installer URLs are handled more consistently during WinGet submissions.
  - Release manifests are generated and submitted automatically when a compatible ZIP release asset is available.
  - Releases without a valid ZIP asset are flagged instead of creating incomplete submissions.
  - Completed package submissions and related cleanup tasks are handled automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->