### PR TITLE
Fix driver store matching and add multi-version purge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,15 @@ Use this while iterating on `neflib` source before it's ready to publish:
    genuinely-valid, still-applicable issues with minimal targeted changes, and explicitly
    skip/justify anything that's pre-existing/out-of-scope/design-level rather than attempting a
    risky broad refactor inside an unrelated PR. Rebuild and re-verify before pushing again.
-6. Once approved, merge the `neflib` PR to its `master`.
+6. **Do not merge on green CI alone.** A passing `build` check says nothing about whether the
+   automated reviewer's findings were actually addressed. Every time the branch is pushed
+   (including follow-up fix commits), re-check for pending review feedback before merging:
+   `gh pr view <num> --json comments -q '.comments[-3:]'` to read the latest CodeRabbit
+   summary/"actionable comments" count for the most recent commit range, and
+   `gh pr view <num> --json reviews` for any human review state (`CHANGES_REQUESTED` etc.).
+   Only merge once the latest review round for the current HEAD has no unresolved actionable
+   findings.
+7. Once approved, merge the `neflib` PR to its `master`.
 
 ### 2. Update the version pointers and publish
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,12 +73,37 @@ Use this while iterating on `neflib` source before it's ready to publish:
    risky broad refactor inside an unrelated PR. Rebuild and re-verify before pushing again.
 6. **Do not merge on green CI alone.** A passing `build` check says nothing about whether the
    automated reviewer's findings were actually addressed. Every time the branch is pushed
-   (including follow-up fix commits), re-check for pending review feedback before merging:
-   `gh pr view <num> --json comments -q '.comments[-3:]'` to read the latest CodeRabbit
-   summary/"actionable comments" count for the most recent commit range, and
-   `gh pr view <num> --json reviews` for any human review state (`CHANGES_REQUESTED` etc.).
-   Only merge once the latest review round for the current HEAD has no unresolved actionable
-   findings.
+   (including follow-up fix commits), re-check for pending review feedback before merging.
+   `gh pr view <num> --json comments -q '.comments[-3:]'` is **not sufficient**: it only shows
+   the last few top-level issue comments, not per-line review threads, and doesn't confirm
+   they refer to the branch's current tip. Instead, query threads and reviews via paginated
+   GraphQL, filtered against the PR's current `headRefOid`:
+
+   ```powershell
+   gh api graphql -f query='
+     query($owner:String!,$repo:String!,$pr:Int!,$cursor:String) {
+       repository(owner:$owner, name:$repo) {
+         pullRequest(number:$pr) {
+           headRefOid
+           reviews(last:20) { nodes { author { login } state commit { oid } } }
+           reviewThreads(first:100, after:$cursor) {
+             pageInfo { hasNextPage endCursor }
+             nodes {
+               isResolved
+               comments(first:1) { nodes { author { login } body path line } }
+             }
+           }
+         }
+       }
+     }' -f owner=nefarius -f repo=<neflib|nefcon> -F pr=<num>
+   ```
+
+   Page through `reviewThreads` with the returned `endCursor` while `hasNextPage` is true (a
+   large review can exceed 100 threads). Only merge once, for the PR's current `headRefOid`:
+   - every `reviewThreads` node has `isResolved: true` (an unresolved CodeRabbit/human thread
+     means a finding is still pending), and
+   - no `reviews` node from a human reviewer is in `CHANGES_REQUESTED` state without a
+     subsequent approving review.
 7. Once approved, merge the `neflib` PR to its `master`.
 
 ### 2. Update the version pointers and publish

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ All commands require **Administrator** privileges unless noted. Paths may be abs
 | `--remove-class-filter` | Remove upper/lower filter |
 | `--install-filter-driver` | Ordered, race-safe INF-based filter driver install against slow service startup |
 | `--uninstall-filter-driver` | Ordered, race-safe filter removal; never leaves a dangling filter entry, race-safe against slow service teardown |
+| `--remove-driver-store-package` | Surgically purge one or more packages from the driver store by original INF name, without touching any device node |
 | `--create-driver-service` | Create kernel driver service |
 | `--remove-driver-service` | Delete kernel driver service |
 | `--reenumerate-affected` | Bring back devices detached via `--remove-driver-service --attempt-detach-affected` |
@@ -173,9 +174,17 @@ These two commands wrap the same underlying operations as the sections above int
 **`--uninstall-filter-driver`** — Removes a class filter entry and its driver service as one ordered sequence: the filter registry entry is removed and its removal is *confirmed* before the service is touched at all, so it is impossible to end up with a dangling `UpperFilters`/`LowerFilters` entry pointing at a since-deleted service (which can prevent the whole device class from starting). Once removal is confirmed, present devices of the class are automatically restarted, and only then is the driver service deleted; deletion is retried across a short window to absorb the brief race where the kernel hasn't yet released the driver image.
 
 - **Required:** `--position` (`upper` or `lower`), `--service-name`, `--class-guid`
-- **Optional:** `--restart-timeout` — milliseconds to wait per device restart attempt performed automatically after the filter entry is removed, default `10000` (a reboot may still be required for devices that could not be restarted); `--stop-timeout` — milliseconds to wait for the service to stop, default `10000`; `--retry-timeout` — milliseconds to keep retrying service deletion while the driver image is still in use, default `5000`; `--inf-path` — path to the *original* INF file; when given, also purges the matching published package from the driver store (surgical `oemNN.inf` removal, no device nodes touched) after the service has been deleted, default: not purged. If the given path doesn't exist, a warning is logged and the purge is skipped — the command still completes normally instead of failing
-- **Pitfalls:** If the filter registry entry cannot be confirmed removed, the command aborts *before* deleting the service, to avoid the bricking scenario described above — check the error and fix the underlying issue rather than forcing service deletion separately. Because later steps are not rolled back, a failure further along (device restart requiring a reboot, or service deletion exhausting its retries) can leave the filter entry already removed but the service still present; re-running the command is safe (filter removal is idempotent), or use `--remove-driver-service` standalone to finish deleting the service. The driver-store purge is opt-in only via `--inf-path`; it is never performed implicitly
+- **Optional:** `--restart-timeout` — milliseconds to wait per device restart attempt performed automatically after the filter entry is removed, default `10000` (a reboot may still be required for devices that could not be restarted); `--stop-timeout` — milliseconds to wait for the service to stop, default `10000`; `--retry-timeout` — milliseconds to keep retrying service deletion while the driver image is still in use, default `5000`; `--inf-path` — path to the *original* INF file; when given, also purges every driver store package matching this filter's class GUID + service name + the INF's original base name after the service has been deleted (surgical removal, no device nodes touched), default: not purged. If the given path doesn't exist, a warning is logged and the purge is skipped — the command still completes normally instead of failing. By default the purge additionally requires the package's own `[Version]` `Provider`/`DriverVer` to match `--inf-path` exactly (so only the version that was actually installed is removed, not other versions of the same driver that may also be in the store); add `--all-versions` to drop that extra check and remove every version of the matching package instead
+- **Pitfalls:** If the filter registry entry cannot be confirmed removed, the command aborts *before* deleting the service, to avoid the bricking scenario described above — check the error and fix the underlying issue rather than forcing service deletion separately. Because later steps are not rolled back, a failure further along (device restart requiring a reboot, or service deletion exhausting its retries) can leave the filter entry already removed but the service still present; re-running the command is safe (filter removal is idempotent), or use `--remove-driver-service` standalone to finish deleting the service. The driver-store purge is opt-in only via `--inf-path`; it is never performed implicitly. If zero packages match, a warning is logged ("nothing purged") rather than reporting success; if some but not all matching packages fail to delete (e.g. still bound to a device), each failure is logged individually and a reboot is assumed to be required
 - **When to use:** Removing a class filter driver cleanly, especially in unattended/scripted uninstalls where the two-command sequence's race conditions are unacceptable
+
+**`--remove-driver-store-package`** — Standalone command to surgically purge one or more packages from the driver store by original INF name, without touching any device node and without needing to stop/uninstall anything else first. Unlike `--uninstall-filter-driver`'s built-in purge (which is scoped to the filter it just removed), this command can target any package(s) directly, and always considers every version present unless narrowed further.
+
+- **Required:** `--inf-name` — one or more original INF base names to match (e.g. `mydriver.inf`), case-insensitive; comma-separated for more than one (e.g. `--inf-name "driver1.inf,driver2.inf"`), since repeating the flag itself is not supported and only the last occurrence would be used. Required so this command can never be used to sweep the entire driver store
+- **Optional:** `--class-guid` — narrows matches to packages whose INF declares this device setup class; `--service-name` — narrows matches to packages whose INF registers this class filter service (via `UpperFilters`/`LowerFilters`); does **not** match a function driver's plain `[...Services] AddService` entry
+- **Behavior:** Every populated criterion must match (logical AND); a package for which a requested criterion can't be determined (e.g. its class can't be read) is treated as not matching, never purged by accident. Every matching package is attempted independently — a failure on one (e.g. it is still bound to a present device) does not prevent the others from being deleted; each outcome is logged individually and the command exits non-zero if any matching package failed to delete
+- **Pitfalls:** With only `--inf-name` given, every version of every package with that original name is purged, regardless of class or service — add `--class-guid`/`--service-name` to narrow this if multiple unrelated drivers could plausibly share the same generic INF name
+- **When to use:** Cleaning up leftover/orphaned driver store entries (e.g. after a manual driver removal that didn't clean the store, or before reinstalling a driver from scratch) without going through a full filter-driver uninstall sequence
 
 ### Driver service management
 
@@ -289,8 +298,22 @@ nefconw --install-filter-driver --inf-path "MyFilter.inf"
 # is retried for up to 5s (default) if the driver image isn't freed yet.
 nefconw --uninstall-filter-driver --position upper --service-name KeyboardCaster --class-guid 4D36E96B-E325-11CE-BFC1-08002BE10318
 
-# Same, plus purge the published driver-store package once the service is gone.
+# Same, plus purge the published driver-store package once the service is gone. By default this
+# only removes the version matching MyFilter.inf's own [Version] identity.
 nefconw --uninstall-filter-driver --position upper --service-name KeyboardCaster --class-guid 4D36E96B-E325-11CE-BFC1-08002BE10318 --inf-path "MyFilter.inf"
+
+# Same, but remove every version of the package still in the store, not just the one matching
+# MyFilter.inf's exact identity.
+nefconw --uninstall-filter-driver --position upper --service-name KeyboardCaster --class-guid 4D36E96B-E325-11CE-BFC1-08002BE10318 --inf-path "MyFilter.inf" --all-versions
+
+# Standalone driver-store cleanup, independent of any filter-driver uninstall.
+nefconw --remove-driver-store-package --inf-name "myfilter.inf"
+
+# Narrow to a specific class + filter service, e.g. if multiple unrelated drivers could share the name.
+nefconw --remove-driver-store-package --inf-name "myfilter.inf" --class-guid 4D36E96B-E325-11CE-BFC1-08002BE10318 --service-name KeyboardCaster
+
+# Multiple original INF names in one call (comma-separated; repeating --inf-name is not supported).
+nefconw --remove-driver-store-package --inf-name "driver1.inf,driver2.inf"
 ```
 
 ### Driver service management

--- a/src/NefConUtil.cpp
+++ b/src/NefConUtil.cpp
@@ -40,6 +40,13 @@ namespace
     //
     bool ValidateExistingFilePath(const std::string& path, const char* pathDescription);
 
+    //
+    // Splits a comma-separated argument value (e.g. --inf-name's value, since argh's
+    // std::map<std::string, std::string> parameter storage silently discards all but the last
+    // occurrence of a repeated flag) into trimmed, non-empty, wide-string entries.
+    //
+    std::vector<std::wstring> SplitCommaSeparatedNames(const std::string& value);
+
     enum class DeviceExistsResult { Found, NotFound, Error };
 
     DeviceExistsResult DeviceExists(const std::string& hwId, int& errorCode);
@@ -143,24 +150,6 @@ namespace
     //
     void DetachAffectedDevicesForService(const argh::parser& cmdl, const std::string& serviceName);
 
-	//
-	// Derives the base name of the original INF file a driver store package was staged from out
-	// of the package's FileRepository directory name, e.g.
-	// "...\FileRepository\example1.inf_amd64_5ca6d479976bcd98\example1.inf" yields
-	// "example1.inf". Returns std::nullopt if the path doesn't follow the
-	// "<originalInfName>_<arch>_<hash>" layout, so callers can fail closed.
-	//
-	std::optional<std::wstring> TryGetOriginalInfNameOfStorePackage(const std::wstring& driverPackageInfPath);
-
-	//
-	// Returns true when the driver store contains at least one package whose original INF file
-	// name (derived from its FileRepository directory) matches the base name of infPath. Used to
-	// gate the driver-store purge of --uninstall-filter-driver on the package actually belonging
-	// to the INF whose service is being removed, so a package that merely shares the same
-	// [Version] identity cannot be deleted by mistake.
-	//
-	bool IsStorePackageForInf(const std::string& infPath);
-
 #if !defined(NEFCON_WINMAIN)
     void CustomizeEasyLoggingColoredConsole();
 #endif
@@ -185,6 +174,7 @@ int main(int argc, char* argv[])
         "--class-name",
         "--class-guid",
         "--service-name",
+        "--inf-name",
         "--position",
         "--display-name",
         "--bin-path",
@@ -791,7 +781,10 @@ int main(int argc, char* argv[])
         //
         // Step 3 (optional): purge the driver-store package. Opt-in only, and run last so the
         // package is deleted only after the filter entry is confirmed gone and the service has
-        // been deleted (i.e. the driver image is already freed).
+        // been deleted (i.e. the driver image is already freed). Matches by class GUID + filter
+        // service name + original INF name (the same identity already validated above), narrowed
+        // to the exact published [Version] identity unless --all-versions asks to purge every
+        // version of this package still in the store.
         // 
         if (const auto storeInfPath = cmdl({"--inf-path"}).str(); !storeInfPath.empty())
         {
@@ -800,27 +793,175 @@ int main(int argc, char* argv[])
                 logger->warn("The given --inf-path \"%v\" doesn't exist; skipping driver store purge",
                              storeInfPath);
             }
-            else if (!IsStorePackageForInf(storeInfPath))
-            {
-                logger->warn("The driver store does not contain a package for \"%v\"; skipping driver store purge",
-                             storeInfPath);
-            }
-            else if (const auto purgeResult = nefarius::devcon::RemoveDriverStorePackage(
-                nefarius::utilities::ConvertAnsiToWide(storeInfPath), &rebootRequired); !purgeResult)
-            {
-                logger->warn("Failed to purge driver store package, error: %v; a reboot may be required",
-                             purgeResult.error().getErrorMessageA());
-                rebootRequired = true;
-            }
             else
             {
-                logger->info("Driver store package purged successfully");
+                std::string normalizedPath(storeInfPath);
+                std::replace(normalizedPath.begin(), normalizedPath.end(), '/', '\\');
+                const auto pathSeparator = normalizedPath.find_last_of('\\');
+                const std::string infBaseName = pathSeparator != std::string::npos
+                    ? normalizedPath.substr(pathSeparator + 1)
+                    : normalizedPath;
+
+                nefarius::devcon::DriverStorePackageFilter filter;
+                filter.ClassGuid = guid.value();
+                filter.ServiceName = nefarius::utilities::ConvertAnsiToWide(serviceName);
+                filter.OriginalInfNames = {nefarius::utilities::ConvertAnsiToWide(infBaseName)};
+
+                if (cmdl[{"--all-versions"}])
+                {
+                    logger->verbose(1, "Purging every version of the driver store package matching \"%v\"",
+                                    storeInfPath);
+                }
+                else if (const auto identity = nefarius::devcon::ReadDriverStoreIdentityFromInf(
+                    nefarius::utilities::ConvertAnsiToWide(storeInfPath).c_str()))
+                {
+                    filter.Provider = identity->Provider;
+                    filter.DriverVer = identity->DriverVer;
+                }
+                else
+                {
+                    logger->warn(
+                        "Could not read the [Version] identity from \"%v\"; purging by class + service + name only, which may remove more than one version",
+                        storeInfPath);
+                }
+
+                const auto purgeResults = nefarius::devcon::RemoveDriverStorePackages(filter, &rebootRequired);
+
+                if (!purgeResults)
+                {
+                    logger->warn("Failed to enumerate the driver store while purging, error: %v",
+                                 purgeResults.error().getErrorMessageA());
+                }
+                else if (purgeResults->empty())
+                {
+                    logger->warn("No matching driver store package found for \"%v\"; nothing purged",
+                                 storeInfPath);
+                }
+                else
+                {
+                    int purgedCount = 0;
+                    int failedCount = 0;
+
+                    for (const auto& result : purgeResults.value())
+                    {
+                        if (result.Removed)
+                        {
+                            purgedCount++;
+                            logger->info("Driver store package purged successfully: %v",
+                                         result.Package.DriverPackageInfPath);
+                        }
+                        else
+                        {
+                            failedCount++;
+                            logger->warn(
+                                "Failed to purge driver store package %v, error: %v; a reboot may be required",
+                                result.Package.DriverPackageInfPath,
+                                result.Error
+                                    ? result.Error->getErrorMessageA()
+                                    : std::string("unknown error"));
+                            rebootRequired = true;
+                        }
+                    }
+
+                    logger->info("Driver store purge: %v of %v matching package(s) removed", purgedCount,
+                                 purgedCount + failedCount);
+                }
             }
         }
 
         if (rebootRequired)
         {
             logger->warn("Filter driver removed, but a reboot may be required to fully complete this operation");
+        }
+
+        return (rebootRequired) ? ERROR_SUCCESS_REBOOT_REQUIRED : EXIT_SUCCESS;
+    }
+
+    if (cmdl[{"--remove-driver-store-package"}])
+    {
+        logger->verbose(1, "Invoked --remove-driver-store-package");
+
+        int errorCode;
+        if (!IsAdmin(errorCode)) return errorCode;
+
+        const auto infNameArg = cmdl({"--inf-name"}).str();
+
+        if (infNameArg.empty())
+        {
+            logger->error("--inf-name missing; refusing to run without at least one original INF name, "
+                          "which would otherwise risk sweeping unrelated driver store packages");
+            return EXIT_FAILURE;
+        }
+
+        nefarius::devcon::DriverStorePackageFilter filter;
+        filter.OriginalInfNames = SplitCommaSeparatedNames(infNameArg);
+
+        if (filter.OriginalInfNames.empty())
+        {
+            logger->error("--inf-name did not contain any usable (non-empty) name");
+            return EXIT_FAILURE;
+        }
+
+        if (const auto classGuidArg = cmdl({"--class-guid"}).str(); !classGuidArg.empty())
+        {
+            const auto guid = nefarius::winapi::GUIDFromString(classGuidArg);
+
+            if (!guid)
+            {
+                logger->error(
+                    "Device Class GUID format invalid, expected format (with or without brackets): xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx");
+                return EXIT_FAILURE;
+            }
+
+            filter.ClassGuid = guid.value();
+        }
+
+        if (const auto serviceNameArg = cmdl({"--service-name"}).str(); !serviceNameArg.empty())
+        {
+            filter.ServiceName = nefarius::utilities::ConvertAnsiToWide(serviceNameArg);
+        }
+
+        bool rebootRequired = false;
+        const auto purgeResults = nefarius::devcon::RemoveDriverStorePackages(filter, &rebootRequired);
+
+        if (!purgeResults)
+        {
+            logger->error("Failed to purge driver store packages, error: %v",
+                          purgeResults.error().getErrorMessageA());
+            return purgeResults.error().getErrorCode();
+        }
+
+        if (purgeResults->empty())
+        {
+            logger->warn("No matching driver store package found for the given criteria; nothing purged");
+            return EXIT_SUCCESS;
+        }
+
+        int purgedCount = 0;
+        int failedCount = 0;
+
+        for (const auto& result : purgeResults.value())
+        {
+            if (result.Removed)
+            {
+                purgedCount++;
+                logger->info("Driver store package purged successfully: %v", result.Package.DriverPackageInfPath);
+            }
+            else
+            {
+                failedCount++;
+                logger->warn("Failed to purge driver store package %v, error: %v",
+                             result.Package.DriverPackageInfPath,
+                             result.Error ? result.Error->getErrorMessageA() : std::string("unknown error"));
+            }
+        }
+
+        logger->info("Driver store purge: %v of %v matching package(s) removed", purgedCount,
+                     purgedCount + failedCount);
+
+        if (failedCount > 0)
+        {
+            return EXIT_FAILURE;
         }
 
         return (rebootRequired) ? ERROR_SUCCESS_REBOOT_REQUIRED : EXIT_SUCCESS;
@@ -1546,6 +1687,11 @@ int main(int argc, char* argv[])
     std::cout << "      --stop-timeout           Milliseconds to wait for the service to stop, default 10000 (optional)" << '\n';
     std::cout << "      --retry-timeout          Milliseconds to keep retrying service deletion while the driver image is still in use, default 5000 (optional)" << '\n';
     std::cout << "      --inf-path               Path to the original INF file; if given, also purges the matching published package from the driver store, default: not purged (optional)" << '\n';
+    std::cout << "      --all-versions           With --inf-path, purge every version of the matching package in the driver store instead of only the one matching its exact [Version] identity (optional)" << '\n';
+    std::cout << "    --remove-driver-store-package Surgically purges one or more packages from the driver store by original INF name, without touching any device node" << '\n';
+    std::cout << "      --inf-name               Comma-separated original INF base name(s) to match, e.g. \"mydriver.inf\" (required)" << '\n';
+    std::cout << "      --class-guid             Device Class GUID the package's INF must declare, narrows matches further (optional)" << '\n';
+    std::cout << "      --service-name           Filter driver service name the package's INF must register (via UpperFilters/LowerFilters), narrows matches further; does NOT match a function driver's plain AddService entry (optional)" << '\n';
     std::cout << "    --create-driver-service    Creates a new service with a kernel driver as binary" << '\n';
     std::cout << "      --bin-path               Path to the .sys file, absolute or relative to CWD (required)" << '\n';
     std::cout << "      --service-name           The driver service name to create (required)" << '\n';
@@ -1663,6 +1809,28 @@ namespace
         }
 
         return true;
+    }
+
+    std::vector<std::wstring> SplitCommaSeparatedNames(const std::string& value)
+    {
+        std::vector<std::wstring> names;
+        std::stringstream stream(value);
+        std::string entry;
+
+        while (std::getline(stream, entry, ','))
+        {
+            const auto first = entry.find_first_not_of(" \t");
+            const auto last = entry.find_last_not_of(" \t");
+
+            if (first == std::string::npos)
+            {
+                continue;
+            }
+
+            names.push_back(nefarius::utilities::ConvertAnsiToWide(entry.substr(first, last - first + 1)));
+        }
+
+        return names;
     }
 
     // ToString(RestartStrategy)/ProblemCodeToString/DescribeFinalDevNodeState/
@@ -2713,119 +2881,6 @@ namespace
 
         return result;
     }
-
-	//
-	// Derives the base name of the original INF file a driver store package was staged from out
-	// of the package's FileRepository directory name, e.g.
-	// "...\FileRepository\example1.inf_amd64_5ca6d479976bcd98\example1.inf" yields
-	// "example1.inf". Returns std::nullopt if the path doesn't follow the
-	// "<originalInfName>_<arch>_<hash>" layout, so callers can fail closed.
-	//
-	std::optional<std::wstring> TryGetOriginalInfNameOfStorePackage(const std::wstring& driverPackageInfPath)
-	{
-		std::wstring packageDirName(driverPackageInfPath);
-		const auto lastSeparator = packageDirName.find_last_of(L'\\');
-
-		if (lastSeparator == std::wstring::npos)
-		{
-			return std::nullopt;
-		}
-
-		//
-		// The staged copy of the INF lives inside its package directory, which is the component
-		// right before the final one when the path ends in the INF file itself.
-		//
-		const std::wstring lastComponent(packageDirName, lastSeparator + 1);
-
-		if (lastComponent.size() >= 4 &&
-			_wcsicmp(lastComponent.c_str() + lastComponent.size() - 4, L".inf") == 0)
-		{
-			packageDirName.erase(lastSeparator);
-
-			const auto dirSeparator = packageDirName.find_last_of(L'\\');
-
-			if (dirSeparator == std::wstring::npos)
-			{
-				return std::nullopt;
-			}
-
-			packageDirName.erase(0, dirSeparator + 1);
-		}
-		else
-		{
-			packageDirName.erase(0, lastSeparator + 1);
-		}
-
-		//
-		// The original name is the prefix up to the last ".inf_" separator (mirrors the
-		// greedy "(.+\.inf)_.+$" extraction used by DriverStoreExplorer).
-		//
-		PCWSTR lastInfoSeparator = nullptr;
-		PCWSTR cursor = packageDirName.c_str();
-
-		while (const auto* occurrence = wcsstr(cursor, L".inf_"))
-		{
-			lastInfoSeparator = occurrence;
-			cursor = occurrence + 1;
-		}
-
-		//
-		// Fail closed: the separator needs a non-empty prefix, and there must be at least one
-		// character (architecture/hash) after it.
-		//
-		if (lastInfoSeparator == nullptr || lastInfoSeparator == packageDirName.c_str() ||
-			lastInfoSeparator + 5 >= packageDirName.c_str() + packageDirName.size())
-		{
-			return std::nullopt;
-		}
-
-		return packageDirName.substr(0,
-			static_cast<size_t>(lastInfoSeparator - packageDirName.c_str()) + 4);
-	}
-
-	//
-	// Returns true when the driver store contains at least one package whose original INF file
-	// name (derived from its FileRepository directory) matches the base name of infPath. Used to
-	// gate the driver-store purge of --uninstall-filter-driver on the package actually belonging
-	// to the INF whose service is being removed, so a package that merely shares the same
-	// [Version] identity cannot be deleted by mistake.
-	//
-	bool IsStorePackageForInf(const std::string& infPath)
-	{
-		el::Logger* logger = el::Loggers::getLogger("default");
-
-		std::string normalizedPath(infPath);
-		std::replace(normalizedPath.begin(), normalizedPath.end(), '/', '\\');
-
-		const auto separator = normalizedPath.find_last_of('\\');
-		const std::string infBaseName = separator != std::string::npos
-			? normalizedPath.substr(separator + 1)
-			: normalizedPath;
-
-		const auto packages = nefarius::devcon::EnumerateDriverStorePackages();
-		if (!packages)
-		{
-			// Distinguish "the store was enumerated and genuinely has no matching package" (the
-			// caller's own follow-up warning covers that) from "we couldn't even enumerate the
-			// store", which would otherwise silently look identical and could mask a real problem
-			// (e.g. a corrupted store) as if the package had simply never been installed.
-			logger->warn("Failed to enumerate the driver store while looking for a package matching \"%v\", error: %v",
-			             infPath, packages.error().getErrorMessageA());
-			return false;
-		}
-
-		for (const auto& package : packages.value())
-		{
-			const auto originalName = TryGetOriginalInfNameOfStorePackage(package.DriverPackageInfPath);
-			if (originalName && _wcsicmp(originalName->c_str(),
-										 nefarius::utilities::ConvertAnsiToWide(infBaseName).c_str()) == 0)
-			{
-				return true;
-			}
-		}
-
-		return false;
-	}
 
 #if !defined(NEFCON_WINMAIN)
     /**

--- a/src/NefConUtil.cpp
+++ b/src/NefConUtil.cpp
@@ -786,6 +786,8 @@ int main(int argc, char* argv[])
         // to the exact published [Version] identity unless --all-versions asks to purge every
         // version of this package still in the store.
         // 
+        bool storePurgeFailed = false;
+
         if (const auto storeInfPath = cmdl({"--inf-path"}).str(); !storeInfPath.empty())
         {
             if (_access(storeInfPath.c_str(), 0) != 0)
@@ -807,7 +809,10 @@ int main(int argc, char* argv[])
                 filter.ServiceName = nefarius::utilities::ConvertAnsiToWide(serviceName);
                 filter.OriginalInfNames = {nefarius::utilities::ConvertAnsiToWide(infBaseName)};
 
-                if (cmdl[{"--all-versions"}])
+                bool skipStorePurge = false;
+                const bool allVersions = cmdl[{"--all-versions"}];
+
+                if (allVersions)
                 {
                     logger->verbose(1, "Purging every version of the driver store package matching \"%v\"",
                                     storeInfPath);
@@ -820,51 +825,67 @@ int main(int argc, char* argv[])
                 }
                 else
                 {
-                    logger->warn(
-                        "Could not read the [Version] identity from \"%v\"; purging by class + service + name only, which may remove more than one version",
+                    //
+                    // Without --all-versions, the caller expects an exact single-version purge.
+                    // Falling back to the version-agnostic filter here would silently widen the
+                    // match to every version of this package, so refuse instead of guessing.
+                    // 
+                    logger->error(
+                        "Could not read the [Version] identity from \"%v\"; refusing to purge without --all-versions, "
+                        "since that would risk removing more than the exact matching package",
                         storeInfPath);
+                    skipStorePurge = true;
+                    storePurgeFailed = true;
                 }
 
-                const auto purgeResults = nefarius::devcon::RemoveDriverStorePackages(filter, &rebootRequired);
+                if (!skipStorePurge)
+                {
+                    const auto purgeResults = nefarius::devcon::RemoveDriverStorePackages(filter, &rebootRequired);
 
-                if (!purgeResults)
-                {
-                    logger->warn("Failed to enumerate the driver store while purging, error: %v",
-                                 purgeResults.error().getErrorMessageA());
-                }
-                else if (purgeResults->empty())
-                {
-                    logger->warn("No matching driver store package found for \"%v\"; nothing purged",
-                                 storeInfPath);
-                }
-                else
-                {
-                    int purgedCount = 0;
-                    int failedCount = 0;
-
-                    for (const auto& result : purgeResults.value())
+                    if (!purgeResults)
                     {
-                        if (result.Removed)
+                        logger->warn("Failed to enumerate the driver store while purging, error: %v",
+                                     purgeResults.error().getErrorMessageA());
+                        storePurgeFailed = true;
+                    }
+                    else if (purgeResults->empty())
+                    {
+                        logger->warn("No matching driver store package found for \"%v\"; nothing purged",
+                                     storeInfPath);
+                    }
+                    else
+                    {
+                        int purgedCount = 0;
+                        int failedCount = 0;
+
+                        for (const auto& result : purgeResults.value())
                         {
-                            purgedCount++;
-                            logger->info("Driver store package purged successfully: %v",
-                                         result.Package.DriverPackageInfPath);
+                            if (result.Removed)
+                            {
+                                purgedCount++;
+                                logger->info("Driver store package purged successfully: %v",
+                                             result.Package.DriverPackageInfPath);
+                            }
+                            else
+                            {
+                                failedCount++;
+                                logger->warn(
+                                    "Failed to purge driver store package %v, error: %v",
+                                    result.Package.DriverPackageInfPath,
+                                    result.Error
+                                        ? result.Error->getErrorMessageA()
+                                        : std::string("unknown error"));
+                            }
                         }
-                        else
+
+                        logger->info("Driver store purge: %v of %v matching package(s) removed", purgedCount,
+                                     purgedCount + failedCount);
+
+                        if (failedCount > 0)
                         {
-                            failedCount++;
-                            logger->warn(
-                                "Failed to purge driver store package %v, error: %v; a reboot may be required",
-                                result.Package.DriverPackageInfPath,
-                                result.Error
-                                    ? result.Error->getErrorMessageA()
-                                    : std::string("unknown error"));
-                            rebootRequired = true;
+                            storePurgeFailed = true;
                         }
                     }
-
-                    logger->info("Driver store purge: %v of %v matching package(s) removed", purgedCount,
-                                 purgedCount + failedCount);
                 }
             }
         }
@@ -872,6 +893,12 @@ int main(int argc, char* argv[])
         if (rebootRequired)
         {
             logger->warn("Filter driver removed, but a reboot may be required to fully complete this operation");
+        }
+
+        if (storePurgeFailed)
+        {
+            logger->error("Filter driver removed, but the driver store purge did not fully complete");
+            return EXIT_FAILURE;
         }
 
         return (rebootRequired) ? ERROR_SUCCESS_REBOOT_REQUIRED : EXIT_SUCCESS;

--- a/src/NefConUtil.h
+++ b/src/NefConUtil.h
@@ -29,6 +29,7 @@
 // 
 #include <iostream>
 #include <fstream>
+#include <sstream>
 #include <filesystem>
 #include <algorithm>
 #include <cctype>

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -3,7 +3,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/nefarius/nefarius-vcpkg-registry.git",
-      "baseline": "359635d7cd8cf52bc91ab528133d4c68dcbe7d99",
+      "baseline": "31727b42818bd4a300c14e12f6dd249f9f669164",
       "packages": [ "neflib" ]
     }
   ],


### PR DESCRIPTION
## Summary
- Audited PR #43's driver store matcher against real machine data (810 packages, several with genuine multi-version duplicates) and fixed three confirmed defects in `neflib`:
  - False "purged successfully" reporting when a same-named package of a different version exists in the store.
  - Duplicated, diverging INF-name matching logic between `nefcon` and `neflib`.
  - The `DiUninstallDriverW` fallback being handed the wrong INF path after a positive match.
- Added a new `neflib` query/removal surface (`DriverStorePackageFilter`, `FindDriverStorePackages`, `RemoveDriverStorePackages`) with per-candidate `--verbose` diagnostics and dependency-free unit tests for the pure matching/parsing logic.
- Exposed multi-version purge in `nefcon` two ways: `--all-versions` on `--uninstall-filter-driver`, and a new standalone `--remove-driver-store-package` command; `--uninstall-filter-driver` now reports match counts and per-package outcomes instead of a possibly-false success.
- Bumped the `neflib` submodule to the merged [neflib#13](https://github.com/nefarius/neflib/pull/13) (tagged `v1.9.0`), published `v1.9.0` to the private vcpkg registry, and bumped `vcpkg-configuration.json`'s baseline accordingly.
- Documented both new CLI surfaces and the underlying `neflib` API in the respective READMEs.

## Test plan
- [x] `neflib-tests.exe` passes, including new `DriverStoreTests.cpp` coverage for `GetOriginalInfNameOfStorePackage` and the filter predicate.
- [x] `neflib` PR #13 CI (build + CodeRabbit) green; CodeRabbit follow-up (uninitialized `RebootRequired` read) fixed and re-verified.
- [x] `nefcon` built successfully locally against the local `neflib` overlay (`NEFCON_LOCAL_NEFLIB=1`).
- [x] `nefcon` rebuilt from a clean `vcpkg_installed` with `NEFCON_LOCAL_NEFLIB` unset, confirming `neflib:x64-windows-static@1.9.0` resolves from the registry and the build succeeds.
- [ ] Manual verification against a real driver store (single-version purge, mismatched-version warning, `--all-versions` removing every copy, wrong `--class-guid`/`--service-name` matching nothing) — still pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added targeted driver-store cleanup by INF name, with optional class-GUID and service-name filters.
  - Added comma-separated INF-name support.
  - Added options to remove matching driver versions or all versions.
  - Added per-package cleanup outcomes.

- **Bug Fixes**
  - Improved filter-driver uninstall handling for partial or empty purges.
  - Added retry handling when filter services remain during installation.
  - Unrecognized or incomplete commands now correctly report failure.

- **Documentation**
  - Updated command references and examples for cleanup, filtering, and version-scoped removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->